### PR TITLE
[#73] Add important Jenkins build information to build description

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,6 +60,7 @@ node {
             Globals.baseVersion = version[1]
             Globals.localVersion = version[2]
 
+            currentBuild.description = "${Globals.baseVersion} ${Globals.localVersion} ${params.GitBranch}"
             print("Base version " + Globals.baseVersion + " local version " + Globals.localVersion)
 
             print('Building shared artifact')

--- a/deploy/create-cluster.Jenkinsfile
+++ b/deploy/create-cluster.Jenkinsfile
@@ -2,6 +2,8 @@ node {
     try{
         stage('Checkout GIT'){
             checkout scm
+
+            currentBuild.description = "${params.Profile} ${params.GitBranch}"
         }
         
         stage('Install tools package'){

--- a/deploy/deploy-legion-enclave.Jenkinsfile
+++ b/deploy/deploy-legion-enclave.Jenkinsfile
@@ -5,6 +5,8 @@ node {
         stage('Checkout GIT'){
             def scmVars = checkout scm
             targetBranch = scmVars.GIT_COMMIT
+
+            currentBuild.description = "${params.EnclaveName} ${params.Profile} ${params.GitBranch}"
         }
         
         stage('Deploy Legion Enclave') {

--- a/deploy/deploy-legion.Jenkinsfile
+++ b/deploy/deploy-legion.Jenkinsfile
@@ -5,6 +5,8 @@ node {
         stage('Checkout GIT'){
             def scmVars = checkout scm
             targetBranch = scmVars.GIT_COMMIT
+
+            currentBuild.description = "${params.Profile} ${params.GitBranch}"
         }
         
         stage('Install tools package'){

--- a/deploy/terminate-cluster.Jenkinsfile
+++ b/deploy/terminate-cluster.Jenkinsfile
@@ -3,6 +3,8 @@ node {
         stage('Checkout GIT'){
             def scmVars = checkout scm
             targetBranch = scmVars.GIT_COMMIT
+
+            currentBuild.description = "${params.Profile} ${params.GitBranch}"
         }
 
         stage('Terminate Cluster') {

--- a/deploy/terminate-legion-enclave.Jenkinsfile
+++ b/deploy/terminate-legion-enclave.Jenkinsfile
@@ -5,6 +5,8 @@ node {
         stage('Checkout GIT'){
             def scmVars = checkout scm
             targetBranch = scmVars.GIT_COMMIT
+
+            currentBuild.description = "${params.EnclaveName} ${params.Profile} ${params.GitBranch}"
         }
  
         stage('Terminate Legion Enclave') {


### PR DESCRIPTION
I added important information about job runs into their description. That makes easier search.
This closes #73 