### PR TITLE
[#41] Repair code of tests K8S autoscaler

### DIFF
--- a/tests/2_check_models.robot
+++ b/tests/2_check_models.robot
@@ -15,7 +15,7 @@ Running, waiting and checks jobs in Jenkins
 
 Check Vertical Scailing
     [Documentation]  Runs "PERF TEST Vertical-Scaling" jenkins job to test vertical scailing
-    [Tags] jenkins model
+    [Tags]  jenkins model
     Connect to Jenkins endpoint
     Run Jenkins job                                         PERF TEST Vertical-Scaling
     Wait Jenkins job                                        PERF TEST Vertical-Scaling   600


### PR DESCRIPTION
This PR fixes error, that has been merged in PR #67 
Error consists of typo in Robot tests.