### PR TITLE
Pin ingress-nginx patch to latest stable version

### DIFF
--- a/deploy/ansible/roles/k8s_resources/defaults/main.yml
+++ b/deploy/ansible/roles/k8s_resources/defaults/main.yml
@@ -2,3 +2,4 @@
 
 prometheus_operator: 0.0.15
 kube_prometheus: 0.0.43
+ingress-nginx: nginx-0.15.0

--- a/deploy/ansible/roles/k8s_resources/tasks/ingress.yaml
+++ b/deploy/ansible/roles/k8s_resources/tasks/ingress.yaml
@@ -24,7 +24,7 @@
 - name: Patch Ingress controller
   shell: |
     kubectl --context {{ cluster_name }} patch deployment -n ingress-nginx nginx-ingress-controller --type='json' \
-        --patch="$(curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/publish-service-patch.yaml)"
+        --patch="$(curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/{{ ingress-nginx }}/deploy/publish-service-patch.yaml)"
 
 - name: Deploy aws ingress
   shell: |


### PR DESCRIPTION
ingress-nginx patch was removed from master branch in 3rd party repo which we are using for deployment.
Before we sorted out all 3rd party modules (issue #120 ) in our code base we should pin version of the module to the latest one which was used.